### PR TITLE
Fix: Notify users about new task comment

### DIFF
--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -27,7 +27,7 @@ teamwork::add_comment() {
   response=$(curl -X "POST" "$TEAMWORK_URI/projects/api/v1/tasks/$TEAMWORK_TASK_ID/comments.json" \
        -u "$TEAMWORK_API_TOKEN"':' \
        -H 'Content-Type: application/json; charset=utf-8' \
-       -d "{ \"comment\": { \"body\": \"${body//\"/}\", \"notify\": \"\", \"content-type\": \"text\", \"isprivate\": false } }" )
+       -d "{ \"comment\": { \"body\": \"${body//\"/}\", \"notify\": true, \"content-type\": \"text\", \"isprivate\": false } }" )
 
   log::message "$response"
 }


### PR DESCRIPTION
Notifies people from the task that a new comment was added. This is important for the support team to know that there was progress on the task.

Fixes #23