### PR TITLE
Have different message when a closed PR is merged or not

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -28,6 +28,10 @@ github::get_pr_title() {
   jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH"
 }
 
+github::get_pr_merged() {
+  jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH"
+}
+
 github::get_sender_user() {
   jq --raw-output .sender.login "$GITHUB_EVENT_PATH"
 }

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -47,11 +47,19 @@ teamwork::pull_request_closed() {
   local -r user=$(github::get_sender_user)
   local -r pr_url=$(github::get_pr_url)
   local -r pr_title=$(github::get_pr_title)
+  local -r pr_merged=$(github::get_pr_merged)
 
-  teamwork::add_comment "
-  **$user** merged a PR: **$pr_title**
-  [$pr_url]($pr_url)
-  "
+  if [ "$pr_merged" == "true" ]; then
+    teamwork::add_comment "
+**$user** merged a PR: **$pr_title**
+[$pr_url]($pr_url)
+"
+  else
+    teamwork::add_comment "
+**$user** closed a PR without merging: **$pr_title**
+[$pr_url]($pr_url)
+"
+  fi
 }
 
 teamwork::pull_request_review_submitted() {

--- a/tests/events/pull_request_closed.json
+++ b/tests/events/pull_request_closed.json
@@ -1,0 +1,18 @@
+{
+  "action": "closed",
+  "number": 1,
+  "pull_request": {
+    "body": "This is the body of the PR. https://xxxx.teamwork.com/#/tasks/123 https://xxx.teamwork.com/#/tasks/456",
+    "head": {
+      "repo": {
+        "full_name": "teamwork/github-sync"
+      }
+    },
+    "html_url": "https://github.com/teamwork/github-sync/pull/1",
+    "title": "This is an example of a title for the PR.",
+    "merged": false
+  },
+  "sender": {
+    "login": "username"
+  }
+}

--- a/tests/events/pull_request_merged.json
+++ b/tests/events/pull_request_merged.json
@@ -1,7 +1,6 @@
 {
   "action": "closed",
   "number": 1,
-  "merged": true,
   "pull_request": {
     "body": "This is the body of the PR. https://xxxx.teamwork.com/#/tasks/123 https://xxx.teamwork.com/#/tasks/456",
     "head": {
@@ -10,7 +9,8 @@
       }
     },
     "html_url": "https://github.com/teamwork/github-sync/pull/1",
-    "title": "This is an example of a title for the PR."
+    "title": "This is an example of a title for the PR.",
+    "merged": true
   },
   "sender": {
     "login": "username"


### PR DESCRIPTION
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #25 
Have different messages for when a closed pr is merged or not.