### PR TITLE
Adding support for Column changes on Tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,6 @@ jobs:
           TEAMWORK_URI: "localhost"
           TEAMWORK_API_TOKEN: "test_api_token"
           AUTOMATIC_TAGGING: true
+          BOARD_COLUMN_OPENED: "PR Open"
+          BOARD_COLUMN_MERGED: "Ready to Test"
+          BOARD_COLUMN_CLOSED: "Rejected"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ jobs:
           TEAMWORK_URI: ${{ secrets.TEAMWORK_URI }}
           TEAMWORK_API_TOKEN: ${{ secrets.TEAMWORK_API_TOKEN }}
           AUTOMATIC_TAGGING: false
+          BOARD_COLUMN_OPENED: 'PR Open'
+          BOARD_COLUMN_MERGED: 'Ready to Test'
+          BOARD_COLUMN_CLOSED: 'Rejected'
 
 ```
 
@@ -65,6 +68,13 @@ Tags are added automatically on the task if you are have the option `AUTOMATIC_T
 - A PR is approved: tag `PR Approved` added
 - A PR is merged: tags `PR Open` and `PR Approved` removed, tag `PR merged` added
 - A PR is closed: tags `PR Open` and `PR Approved` removed
+
+You may also specify columns you'd like the task to be moved to on every stage of the PR:
+- `BOARD_COLUMN_OPENED`: The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been opened
+- `BOARD_COLUMN_MERGED`: The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been merged
+- `BOARD_COLUMN_CLOSED`: The case-sensiteve column name of the column you'd like the task to be moved to if the PR was closed without being merged
+
+The column names will be checked against all board columns in the task's project, this will be using a `contains()` method so you may specify part of the name instead of the full name, however this `contains()` check is case-sensitive. The first matching column will be used.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ jobs:
           TEAMWORK_URI: ${{ secrets.TEAMWORK_URI }}
           TEAMWORK_API_TOKEN: ${{ secrets.TEAMWORK_API_TOKEN }}
           AUTOMATIC_TAGGING: false
-          BOARD_COLUMN_OPENED: 'PR Open'
-          BOARD_COLUMN_MERGED: 'Ready to Test'
-          BOARD_COLUMN_CLOSED: 'Rejected'
+          BOARD_COLUMN_OPENED: "PR Open"
+          BOARD_COLUMN_MERGED: "Ready to Test"
+          BOARD_COLUMN_CLOSED: "Rejected"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ jobs:
           TEAMWORK_URI: ${{ secrets.TEAMWORK_URI }}
           TEAMWORK_API_TOKEN: ${{ secrets.TEAMWORK_API_TOKEN }}
           AUTOMATIC_TAGGING: false
-          BOARD_COLUMN_OPENED: "PR Open"
-          BOARD_COLUMN_MERGED: "Ready to Test"
-          BOARD_COLUMN_CLOSED: "Rejected"
+          BOARD_COLUMN_OPENED: 'PR Open'
+          BOARD_COLUMN_MERGED: 'Ready to Test'
+          BOARD_COLUMN_CLOSED: 'Rejected'
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,18 @@ inputs:
   AUTOMATIC_TAGGING:
     description: 'Do you want to enable automatic tagging: true/false'
     required: false
+  BOARD_COLUMN_OPENED:
+    description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been opened'
+    required: false
+    default: ''
+  BOARD_COLUMN_MERGED:
+    description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been merged'
+    required: false
+    default: ''
+  BOARD_COLUMN_CLOSED:
+    description: 'The case-sensiteve column name of the column you'd like the task to be moved to if the PR was closed without being merged'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -24,3 +36,6 @@ runs:
     - ${{ inputs.TEAMWORK_URI }}
     - ${{ inputs.TEAMWORK_API_TOKEN }}
     - ${{ inputs.AUTOMATIC_TAGGING }}
+    - ${{ inputs.BOARD_COLUMN_OPENED }}
+    - ${{ inputs.BOARD_COLUMN_MERGED }}
+    - ${{ inputs.BOARD_COLUMN_CLOSED }}

--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,12 @@ inputs:
   BOARD_COLUMN_OPENED:
     description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been opened'
     required: false
-    default: ''
   BOARD_COLUMN_MERGED:
     description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been merged'
     required: false
-    default: ''
   BOARD_COLUMN_CLOSED:
     description: 'The case-sensiteve column name of the column you'd like the task to be moved to if the PR was closed without being merged'
     required: false
-    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,17 @@ inputs:
     description: 'Do you want to enable automatic tagging: true/false'
     required: false
   BOARD_COLUMN_OPENED:
-    description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been opened'
+    description: 'The case-sensiteve column name of the column you would like the task to be moved to once the PR has been opened'
     required: false
+    default: ''
   BOARD_COLUMN_MERGED:
-    description: 'The case-sensiteve column name of the column you'd like the task to be moved to once the PR has been merged'
+    description: 'The case-sensiteve column name of the column you would like the task to be moved to once the PR has been merged'
     required: false
+    default: ''
   BOARD_COLUMN_CLOSED:
-    description: 'The case-sensiteve column name of the column you'd like the task to be moved to if the PR was closed without being merged'
+    description: 'The case-sensiteve column name of the column you would like the task to be moved to if the PR was closed without being merged'
     required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/main.sh
+++ b/src/main.sh
@@ -17,6 +17,9 @@ main() {
   export TEAMWORK_URI="$2"
   export TEAMWORK_API_TOKEN="$3"
   export AUTOMATIC_TAGGING="$4"
+  export BOARD_COLUMN_OPENED="$5"
+  export BOARD_COLUMN_MERGED="$6"
+  export BOARD_COLUMN_CLOSED="$7"
 
   env::set_environment
 
@@ -39,6 +42,7 @@ main() {
     log::message "Task found with the id: $task_id"
 
     export TEAMWORK_TASK_ID=$task_id
+    export TEAMWORK_PROJECT_ID="$(teamwork::get_project_id_from_task "$task_id")"
 
     if [ "$event" == "pull_request" ] && [ "$action" == "opened" ]; then
       teamwork::pull_request_opened

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -16,6 +16,74 @@ teamwork::get_task_id_from_body() {
   echo "$task_ids_str"
 }
 
+teamwork::get_project_id_from_task() {
+  local -r task_id=$1
+
+  if [ "$ENV" == "test" ]; then
+    echo "$task_id"
+    return
+  fi
+
+  response=$(
+    curl "$TEAMWORK_URI/projects/api/v1/tasks/$task_id.json" -u "$TEAMWORK_API_TOKEN"':' |\
+      jq -r '.["todo-item"]["project-id"]'
+  )
+  echo "$response"
+}
+
+teamwork::get_matching_board_column_id() {
+  local -r column_name=$1
+
+  if [ -z "$column_name" ]; then
+    return
+  fi
+
+  if [ "$ENV" == "test" ]; then
+    echo "$TEAMWORK_PROJECT_ID"
+    return
+  fi
+
+  response=$(
+    curl "$TEAMWORK_URI/projects/$TEAMWORK_PROJECT_ID/boards/columns.json" -u "$TEAMWORK_API_TOKEN"':' |\
+      jq -r --arg column_name "$column_name" '[.columns[] | select(.name | contains($column_name))] | map(.id)[0]'
+  )
+
+  if [ "$response" = "null" ]; then
+    return
+  fi
+
+  echo "$response"
+}
+
+teamwork::move_task_to_column() {
+  local -r task_id=$TEAMWORK_TASK_ID
+  local -r column_name=$1
+
+  if [ -z "$column_name" ]; then
+    log::message "No column name provided"
+    return
+  fi
+
+  local -r column_id=$(teamwork::get_matching_board_column_id $column_name)
+
+  if [ -z "$column_id" ]; then
+    log::message "Failed to find a matching board column for '$column_name'"
+    return
+  fi
+
+  if [ "$ENV" == "test" ]; then
+    log::message "Test - Simulate request. Task ID: $TEAMWORK_TASK_ID - Project ID: $TEAMWORK_PROJECT_ID - Column ID: $column_id"
+    return
+  fi
+
+  response=$(curl -X "PUT" "$TEAMWORK_URI/tasks/$TEAMWORK_TASK_ID.json" \
+       -u "$TEAMWORK_API_TOKEN"':' \
+       -H 'Content-Type: application/json; charset=utf-8' \
+       -d "{ \"todo-item\": { \"columnId\": $column_id } }" )
+
+  log::message "$response"
+}
+
 teamwork::add_comment() {
   local -r body=$1
 
@@ -90,6 +158,7 @@ ${pr_body//###/####}
   "
 
   teamwork::add_tag "PR Open"
+  teamwork::move_task_to_column "$BOARD_COLUMN_OPENED"
 }
 
 teamwork::pull_request_closed() {
@@ -106,6 +175,7 @@ teamwork::pull_request_closed() {
   teamwork::add_tag "PR Merged"
   teamwork::remove_tag "PR Open"
   teamwork::remove_tag "PR Approved"
+  teamwork::move_task_to_column "$BOARD_COLUMN_MERGED"
   else
     teamwork::add_comment "
 **$user** closed a PR without merging: **$pr_title**
@@ -113,6 +183,7 @@ teamwork::pull_request_closed() {
 "
     teamwork::remove_tag "PR Open"
     teamwork::remove_tag "PR Approved"
+    teamwork::move_task_to_column "$BOARD_COLUMN_CLOSED"
   fi
 }
 


### PR DESCRIPTION
# About
This PR adds the capability to move tasks across Columns in Project during the different stages of a PR.

# How
I'm introducing three new inputs: `BOARD_COLUMN_OPENED`, `BOARD_COLUMN_MERGED` and `BOARD_COLUMN_CLOSED`. The tasks would be moved to the specified columns as the PR is opened, merged or closed (respectively).

On our workflow this would be extremely helpful, since we use the Board view in Teamwork to visually see what's the status on each task, we would start the task by moving it to "In Development", then once a PR is open we move it to "Has PR" and finally once the PR is merged the task is ready to be tested and moved to "Nightly". Optionally we may move the task back to "Selected For Development" in case the PR was rejected and closed.