### PR TITLE
Feature: Show head & base ref, cap markdown headings to h4

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -13,7 +13,15 @@ github::get_pr_number() {
 }
 
 github::get_pr_body() {
-  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH"
+  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH" | sed -r 's/#{1,3}/####/'
+}
+
+github::get_head_ref() {
+  jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH"
+}
+
+github::get_base_ref() {
+  jq --raw-output .pull_request.base.ref "$GITHUB_EVENT_PATH"
 }
 
 github::get_repository_full_name() {

--- a/src/github.sh
+++ b/src/github.sh
@@ -13,7 +13,7 @@ github::get_pr_number() {
 }
 
 github::get_pr_body() {
-  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH" | sed -r 's/^#{1,3}\ /#### /'
+  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH" | sed -r 's/^#{1,3}\ /#### /g'
 }
 
 github::get_head_ref() {

--- a/src/github.sh
+++ b/src/github.sh
@@ -13,7 +13,7 @@ github::get_pr_number() {
 }
 
 github::get_pr_body() {
-  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH" | sed -r 's/#{1,3}/####/'
+  jq --raw-output .pull_request.body "$GITHUB_EVENT_PATH" | sed -r 's/^#{1,3}\ /#### /'
 }
 
 github::get_head_ref() {

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -71,6 +71,8 @@ teamwork::remove_tag() {
 teamwork::pull_request_opened() {
   local -r pr_url=$(github::get_pr_url)
   local -r pr_title=$(github::get_pr_title)
+  local -r head_ref=$(github::get_head_ref)
+  local -r base_ref=$(github::get_base_ref)
   local -r user=$(github::get_sender_user)
   local -r pr_stats=$(github::get_pr_patch_stats)
   local -r pr_body=$(github::get_pr_body)
@@ -79,14 +81,16 @@ teamwork::pull_request_opened() {
   teamwork::add_comment "
 **$user** opened a PR: **$pr_title**
 [$pr_url]($pr_url)
+`$base_ref` <- `$head_ref`
 
 ---
 
-${pr_body//###/####} 
+${pr_body}
 
 ---
 
 🔢 ${pr_stats_array[0]} commits / 📝 ${pr_stats_array[1]} files updated / ➕ ${pr_stats_array[2]} additions / ➖ ${pr_stats_array[3]} deletions
+
   "
 
   teamwork::add_tag "PR Open"

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -81,7 +81,7 @@ teamwork::pull_request_opened() {
   teamwork::add_comment "
 **$user** opened a PR: **$pr_title**
 [$pr_url]($pr_url)
-`$base_ref` <- `$head_ref`
+\`$base_ref\` <- \`$head_ref\`
 
 ---
 

--- a/tests/events/pull_request_opened.json
+++ b/tests/events/pull_request_opened.json
@@ -4,9 +4,13 @@
   "pull_request": {
     "body": "This is the body of the PR. https://xxxx.teamwork.com/#/tasks/123 https://xxx.teamwork.com/#/tasks/456",
     "head": {
+      "ref": "pr-branch",
       "repo": {
         "full_name": "teamwork/github-sync"
       }
+    },
+    "base": {
+      "ref": "main"
     },
     "html_url": "https://github.com/teamwork/github-sync/pull/1",
     "title": "This is an example of a title for the PR.",

--- a/tests/events/pull_request_opened.json
+++ b/tests/events/pull_request_opened.json
@@ -2,7 +2,7 @@
   "action": "opened",
   "number": 1,
   "pull_request": {
-    "body": "This is the body of the PR. https://xxxx.teamwork.com/#/tasks/123 https://xxx.teamwork.com/#/tasks/456",
+    "body": "# Test heading \n This is the body of the PR. https://xxxx.teamwork.com/#/tasks/123 https://xxx.teamwork.com/#/tasks/456",
     "head": {
       "ref": "pr-branch",
       "repo": {


### PR DESCRIPTION
Added the base and head branches. Found myself losing context sometimes & to avoid going between github & teamwork, I'd rather have the branch information in teamwork itself. 

Also added the base ref, useful when working in a long standing feature branch

Finally, I've capped all headings to h4 , as the headings in teamwork's markdown are quite big