### PR TITLE
Fix: Unbound variable causing script to fail

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -46,7 +46,7 @@ main() {
     project_id="$(teamwork::get_project_id_from_task "$task_id")"
     export TEAMWORK_PROJECT_ID=$project_id
 
-    ignored_project_ids=("$IGNORE_PROJECT_IDS")
+    ignored_project_ids=("${IGNORE_PROJECT_IDS:-}")
     if (( ${#ignored_project_ids[@]} != 0 )) || utils::in_array "$1" "${ignored_project_ids[*]}"
     then
         log::message "ignored due to IGNORE_PROJECT_IDS"


### PR DESCRIPTION
When the environment variable `IGNORE_PROJECT_IDS` is not provided the GithubAction is failing with the error:

```
/src/main.sh: line 49: IGNORE_PROJECT_IDS: unbound variable
```

Setting a default empty value should solve the issue.