### PR TITLE
Feature: Lightweight comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
 ```
 
 ## Usage
-When creating a new PR, write in the description of the PR the URL of the task. The action will automatically add a comment in the task.
+When creating a new PR, write in the description of the PR the URL of the task. The action will automatically add a comment in the task. Optionally, you may choose for a lightweight comment that will only include the PR URL and the user that performed the action, to enable this option set the `LIGHTWEIGHT_COMMENT` input to `true`.
 
 Please note, the comment will be created in Teamwork under the account you have attached to this action. If the API key of the user you are using does not have permissions to access certain projects, the comment will not be created.
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'The case-sensitive column name of the column you would like the task to be moved to if the PR was closed without being merged'
     required: false
     default: ''
+  LIGHTWEIGHT_COMMENT:
+    description: 'Generate tiny comments with minimal information'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -39,3 +43,4 @@ runs:
     - ${{ inputs.BOARD_COLUMN_OPENED }}
     - ${{ inputs.BOARD_COLUMN_MERGED }}
     - ${{ inputs.BOARD_COLUMN_CLOSED }}
+    - ${{ inputs.LIGHTWEIGHT_COMMENT }}

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,6 +20,7 @@ main() {
   export BOARD_COLUMN_OPENED="$5"
   export BOARD_COLUMN_MERGED="$6"
   export BOARD_COLUMN_CLOSED="$7"
+  export LIGHTWEIGHT_COMMENT="$8"
 
   env::set_environment
 


### PR DESCRIPTION
New option to add a small comment to the task, only with minimal information. This should help link pull requests with Teamwork.com tasks without "polluting" ongoing discussions.