### PR TITLE
Include PR title in lightweight comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
 ```
 
 ## Usage
-When creating a new PR, write in the description of the PR the URL of the task. The action will automatically add a comment in the task. Optionally, you may choose for a lightweight comment that will only include the PR URL and the user that performed the action, to enable this option set the `LIGHTWEIGHT_COMMENT` input to `true`.
+When creating a new PR, write in the description of the PR the URL of the task. The action will automatically add a comment in the task. Optionally, you may choose for a lightweight comment that will only include the PR title, URL and the user that performed the action, to enable this option set the `LIGHTWEIGHT_COMMENT` input to `true`.
 
 Please note, the comment will be created in Teamwork under the account you have attached to this action. If the API key of the user you are using does not have permissions to access certain projects, the comment will not be created.
 

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -146,7 +146,7 @@ teamwork::pull_request_opened() {
   IFS=" " read -r -a pr_stats_array <<< "$pr_stats"
 
   if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-    teamwork::add_comment "[PR]($pr_url) opened by $user"
+    teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) opened by $user"
   else
     teamwork::add_comment "
 **$user** opened a PR: **$pr_title**
@@ -176,7 +176,7 @@ teamwork::pull_request_closed() {
 
   if [ "$pr_merged" == "true" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) merged by $user"
+      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) merged by $user"
     else
       teamwork::add_comment "
 **$user** merged a PR: **$pr_title**
@@ -189,7 +189,7 @@ teamwork::pull_request_closed() {
     teamwork::move_task_to_column "$BOARD_COLUMN_MERGED"
   else
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) closed without merging by $user"
+      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) closed without merging by $user"
     else
       teamwork::add_comment "
 **$user** closed a PR without merging: **$pr_title**
@@ -212,7 +212,7 @@ teamwork::pull_request_review_submitted() {
   # Only add a message if the PR has been approved
   if [ "$review_state" == "approved" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) approved by $user"
+      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) approved by $user"
     else
       teamwork::add_comment "
 **$user** submitted a review to the PR: **$pr_title**

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -146,7 +146,7 @@ teamwork::pull_request_opened() {
   IFS=" " read -r -a pr_stats_array <<< "$pr_stats"
 
   if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-    teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) opened by $user"
+    teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) opened by **$user**"
   else
     teamwork::add_comment "
 **$user** opened a PR: **$pr_title**
@@ -176,7 +176,7 @@ teamwork::pull_request_closed() {
 
   if [ "$pr_merged" == "true" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) merged by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) merged by **$user**"
     else
       teamwork::add_comment "
 **$user** merged a PR: **$pr_title**
@@ -189,7 +189,7 @@ teamwork::pull_request_closed() {
     teamwork::move_task_to_column "$BOARD_COLUMN_MERGED"
   else
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) closed without merging by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) closed without merging by **$user**"
     else
       teamwork::add_comment "
 **$user** closed a PR without merging: **$pr_title**
@@ -212,7 +212,7 @@ teamwork::pull_request_review_submitted() {
   # Only add a message if the PR has been approved
   if [ "$review_state" == "approved" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) approved by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) approved by **$user**"
     else
       teamwork::add_comment "
 **$user** submitted a review to the PR: **$pr_title**

--- a/src/teamwork.sh
+++ b/src/teamwork.sh
@@ -146,7 +146,7 @@ teamwork::pull_request_opened() {
   IFS=" " read -r -a pr_stats_array <<< "$pr_stats"
 
   if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-    teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) opened by $user"
+    teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) opened by $user"
   else
     teamwork::add_comment "
 **$user** opened a PR: **$pr_title**
@@ -176,7 +176,7 @@ teamwork::pull_request_closed() {
 
   if [ "$pr_merged" == "true" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) merged by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) merged by $user"
     else
       teamwork::add_comment "
 **$user** merged a PR: **$pr_title**
@@ -189,7 +189,7 @@ teamwork::pull_request_closed() {
     teamwork::move_task_to_column "$BOARD_COLUMN_MERGED"
   else
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) closed without merging by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) closed without merging by $user"
     else
       teamwork::add_comment "
 **$user** closed a PR without merging: **$pr_title**
@@ -212,7 +212,7 @@ teamwork::pull_request_review_submitted() {
   # Only add a message if the PR has been approved
   if [ "$review_state" == "approved" ]; then
     if [ "$LIGHTWEIGHT_COMMENT" == "true" ]; then
-      teamwork::add_comment "[PR]($pr_url) [**\"$pr_title\"**]($pr_url) approved by $user"
+      teamwork::add_comment "PR [**\"$pr_title\"**]($pr_url) approved by $user"
     else
       teamwork::add_comment "
 **$user** submitted a review to the PR: **$pr_title**


### PR DESCRIPTION
## Summary

`LIGHTWEIGHT_COMMENT` keeps Teamwork comments brief, but it also dropped the PR title — the comment was just `[PR](url) opened by user`, which gives no hint of *which* PR a task is referring to.

This keeps the comment to a single line but restores the title: the PR title is rendered bold, quoted, and linked to the PR right after the `PR` label, e.g.

> [PR](url) [**"Fix login redirect"**](url) opened by alice

The same treatment is applied to all four lightweight events: opened, merged, closed-without-merge, and review-approved. The verbose (non-lightweight) comments are unchanged. README updated to note the title is now included.

[Test Task](https://twtest.teamwork.com/#/tasks/20613952) <!-- Dummy test task to make sure the test job runs - replace with real link where necessary. -->
