### PR TITLE
Fix Node 20 deprecation

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
       - name: Run Shellcheck
         uses: azohra/shell-linter@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Ensure this project runs
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v5
       - uses: ./
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Fix Node 20 deprecation in github-sync CI workflows

## Summary

GitHub is retiring the **Node 20 action runtime**; actions bundling a Node 20 (or older) entrypoint emit deprecation warnings today and will eventually stop running. This PR bumps the one affected action in this repo's CI.

## Changes

| Action | Before | After (node24) | Occurrences |
|---|---|---|---|
| `actions/checkout` | `@v1` | `@v5` | 2 |

Files touched: `.github/workflows/linter.yml`, `test.yml`. (`checkout@v1` is node12-era, so it was already emitting deprecation warnings.)

### Not applicable / out of scope

- **This repo's own action (`action.yml`) is a Docker container action** (`runs.using: docker`), so it is **not** subject to the Node runtime deprecation — no change needed there.
- `azohra/shell-linter@latest` — Docker container action, unaffected.
- `./` (uses the local Docker action for a self-test) — unaffected.

## Verification

Confirmed via the pinned `action.yml` (`runs.using:`):

- `checkout@v1` → node12; `@v5` → node24

Diff is version strings only, no other edits.

## Runner requirement

Both jobs run on **`ubuntu-latest`** (GitHub-hosted), which already supports the Node 24 runtime — no runner action needed.

## Testing

- [ ] Run the lint + test workflows and confirm the checkout step runs without Node deprecation warnings.
